### PR TITLE
For Webpack pre-4.0 the `hooks` method is not provided.

### DIFF
--- a/src/__tests__/plugin.test.ts
+++ b/src/__tests__/plugin.test.ts
@@ -117,4 +117,12 @@ describe('NetlifyPlugin', () => {
     plugin.apply(compiler);
     expect(c.assets).toEqual({});
   });
+  it('falls back to plugin method if tap is not defined', () => {
+    const plugin = new NetlifyPlugin({});
+    const compiler: any = {
+      plugin: jest.fn()
+    };
+    plugin.apply(compiler);
+    expect(compiler.plugin).toHaveBeenCalledWith('emit', expect.any(Function));
+  });
 });


### PR DESCRIPTION
Patch a fallback to the old version of webpack to allow this plugin
to be used in previous instances.